### PR TITLE
Better error handling in csvquery-server

### DIFF
--- a/cmd/csvquery-server/main.go
+++ b/cmd/csvquery-server/main.go
@@ -10,6 +10,19 @@ import (
 	"github.com/chrismytton/csvquery"
 )
 
+func errorResponse(w http.ResponseWriter, status int, message string) {
+	w.WriteHeader(status)
+	w.Write([]byte(fmt.Sprintf("error\n%s\n", message)))
+}
+
+func badRequest(w http.ResponseWriter, message string) {
+	errorResponse(w, http.StatusBadRequest, message)
+}
+
+func internalServerError(w http.ResponseWriter, message string) {
+	errorResponse(w, http.StatusInternalServerError, message)
+}
+
 func requestHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		return
@@ -17,20 +30,19 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println(r.URL)
 	queryString := r.URL.Query()
 	if len(queryString["table"]) == 0 {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("error\nPlease provide one or more 'table' parameters"))
+		badRequest(w, "Please provide one or more 'table' parameters")
 		return
 	}
 	if len(queryString["query"]) == 0 {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("error\nPlease provide a 'query' parameter"))
+		badRequest(w, "Please provide a 'query' parameters")
 		return
 	}
 	tables := queryString["table"]
 	query := queryString["query"][0]
 	q, err := csvquery.New()
 	if err != nil {
-		log.Fatal(err)
+		internalServerError(w, fmt.Sprintf("An unexpected error occurred: %s. Please try again later. If this error persists, please get in touch.", err))
+		return
 	}
 	defer q.Close()
 
@@ -40,17 +52,20 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 		csvURL := parts[1]
 		resp, err := http.Get(csvURL)
 		if err != nil {
-			log.Fatal(err)
+			badRequest(w, fmt.Sprintf("Couldn't GET URL %s: %s", csvURL, err))
+			return
 		}
 		defer resp.Body.Close()
 		r := csv.NewReader(resp.Body)
 		records, err := r.ReadAll()
 		if err != nil {
-			log.Fatal(err)
+			badRequest(w, fmt.Sprintf("Couldn't parse CSV from URL %s: %s", csvURL, err))
+			return
 		}
 		err = q.Insert(tableName, records)
 		if err != nil {
-			log.Fatal(err)
+			internalServerError(w, fmt.Sprintf("Error trying to load data: %s", err))
+			return
 		}
 	}
 


### PR DESCRIPTION
Rather than exiting the process whenever an error is encountered, return a friendly error message.